### PR TITLE
Reading files

### DIFF
--- a/node.sh
+++ b/node.sh
@@ -23,21 +23,32 @@ function get_id {
 
 text=
 valence=
+hovertext=
+htext_flag=0
 while test $# -gt 0; do
     case $1 in
-	-)
-	    valence=-1
-	    ;;
-	+)
-	    valence=1
-	    ;;
-	*)
-	    if test "$text"; then
-		text="$text "$1
-	    else
-		text=$1
-	    fi
-	    ;;
+    -)
+        valence=-1
+        ;;
+    +)
+        valence=1
+        ;;
+    --hovertext)
+        htext_flag=1
+        ;;
+    *)
+        if [ $htext_flag -eq 1 ]; then
+            if test "$hovertext"; then
+                hovertext="$hovertext "$1
+            else
+                hovertext=$1
+            fi
+        elif test "$text"; then
+            text="$text "$1
+        else
+            text=$1
+        fi
+        ;;
     esac
     shift
 done
@@ -55,8 +66,8 @@ fi
 id=$(get_id)
 echo $id
 
-jq --arg id $id --arg text "$text" --arg valence $valence \
-   '.nodes += [{id: $id, text: $text, valence: $valence}]' \
+jq --arg id $id --arg text "$text" --arg valence $valence --arg hovertext "$hovertext" \
+   '.nodes += [{id: $id, text: $text, valence: $valence, hovertext: $hovertext}]' \
    <$file >${file}_tmp \
     && mv ${file}_tmp $file
 

--- a/pg
+++ b/pg
@@ -17,8 +17,14 @@ if test "$1" == "ls"; then
     exit
 fi
 
+# accept '-f' flag to read commands from a file
+if test "$1" == "-f"; then
+    export in_file=$2
+    # set and clear reusable data file
+    export file=$path/data/.from_file
+    > $file
 # accept graph name as argument
-if test -z $1; then
+elif test -z $1; then
     # default
     export file=$path/data/test
 else
@@ -34,13 +40,21 @@ if test "$1" == "render"; then
     exit
 fi
 
-while true; do
-    read -p "> " command
+# enter interactive mode if no file specified
+if test -z $in_file; then
+    while true; do
+        read -p "> " command
 
-    if test "$command" == "q"; then
-	exit
-    fi
+        if test "$command" == "q"; then
+        exit
+        fi
 
-    $path/protograph.sh $command
+        $path/protograph.sh $command
 
-done
+    done
+# otherwise execute file line by line
+else
+    while IFS= read -r command; do
+        $path/protograph.sh $command
+    done < $in_file
+fi

--- a/protograph.py
+++ b/protograph.py
@@ -10,7 +10,7 @@ try:
     from sklearn.manifold import MDS
     import scipy
 except ImportError:
-    pass
+    print("(You may get better graph-drawing results if python lib scikit-learn is available)")
 
 # load
 path = sys.argv[1]
@@ -66,16 +66,19 @@ try:
     # start with MDS, if scikit available
     adj = nx.convert_matrix.to_scipy_sparse_matrix(G)
     dist = scipy.sparse.csgraph.dijkstra(adj, directed=False)
+    default = 2
+    print(f'Default distance for MDS set to {default}')
+    dist = np.nan_to_num(dist, nan=default, posinf=default, neginf=default)
     nodes = list(G.nodes)
     coords = MDS(dissimilarity='precomputed').fit_transform(dist)
     pos = {nodes[i]: coords[i] for i in range(len(nodes))}
-except (NameError, ValueError):
-    print("(You may get better graph-drawing results if python lib scikit-learn is available)")
+except (NameError, ValueError) as e:
+    print(e)
     try:
-        pos = nx.drawing.layout.planar_layout(G)
-    except nx.exception.NetworkXException:
-        #pos = nx.drawing.layout.spectral_layout(G)
         pos = nx.drawing.layout.kamada_kawai_layout(G)
+    except nx.exception.NetworkXException:
+        pos = nx.drawing.layout.spectral_layout(G)
+        #pos = nx.drawing.layout.planar_layout(G)
 
 
 # Layout

--- a/protograph.py
+++ b/protograph.py
@@ -155,12 +155,14 @@ for x,y,c in zip(arrows_x, arrows_y, arrow_colors):
 node_x = []
 node_y = []
 node_text = []
+node_hovertext = []
 node_color = []
 for node in G.nodes():
     x, y = pos[node]
     node_x.append(x)
     node_y.append(y)
     node_text.append(G.nodes[node]['text'])
+    node_hovertext.append(G.nodes[node]['hovertext'])
     node_color.append(int(G.nodes[node]['valence']))
 
 node_color = np.where(np.equal(node_color, -1), 'red', np.where(np.equal(node_color, 1), 'green', 'gray'))
@@ -169,7 +171,8 @@ node_trace = go.Scatter(
     x=node_x, y=node_y,
     mode='markers+text',
     #hovertemplate='%{text}<extra></extra>',
-    hoverinfo='skip',
+    hoverinfo='text',
+    hovertext=node_hovertext,
     text=node_text,
     textposition='top center',
     marker=dict(


### PR DESCRIPTION
Allow other tools to invoke pg via reading commands from a file.

`pg -f <filepath>` reads `<filepath>` line by line, executing each (as if from the interactive pg interface). Assume this file contains the whole graph specification, so there's no need to save the resulting data; instead just (re)use a default file `data/.from_file`.

Also some slight bug fixes/tweaks to graph layout.